### PR TITLE
 add basic support for ssb-revisions and ssb-threads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-graphql-defaults",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/message/post/resolver.js
+++ b/src/message/post/resolver.js
@@ -5,7 +5,11 @@ module.exports = {
     type: (msg) => msg.value.content.type,
     text: (msg) => msg.value.content.text,
     root: (msg) => msg.value.content.root,
-    branch: (msg) => msg.value.content.branch,
+    branch: (msg) => {
+      const branch = msg.value.content.branch
+      if(typeof branch === 'string' || branch instanceof String) { return [branch] }
+      return branch
+    },
     revisionRoot: (msg) => msg.value.content.revisionRoot,
     revisionBranch: (msg) => msg.value.content.revisionBranch,
     key: (msg) => msg.key,

--- a/src/message/post/type.js
+++ b/src/message/post/type.js
@@ -12,7 +12,7 @@ const PostMessage = `
     type: String
     author: String
     root: String
-    branch: String
+    branch: [String]
     revisionRoot: String
     revisionBranch: String
   }

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -12,7 +12,7 @@ const { messagesByType, log, feed, history } = require('./message/streams/resolv
 const { unbox, publishPrivate, publishPrivatePost } = require('./message/private/resolver')
 const { replication } = require('./replication/resolver')
 const { revisionStats, revisionHistory } = require('./revisions/resolver')
-const { threads } = require('./threads/resolver')
+const { thread, threads } = require('./threads/resolver')
 const { peers, gossip } = require('./gossip/resolver')
 const { blob, blobRemove, blobsList, blobsChanges } = require('./blobs/resolver')
 
@@ -21,6 +21,7 @@ const Query = {
   message,
   revisionStats,
   revisionHistory,
+  thread,
   threads,
   blob,
   peers,

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -11,12 +11,17 @@ const {
 const { messagesByType, log, feed, history } = require('./message/streams/resolver')
 const { unbox, publishPrivate, publishPrivatePost } = require('./message/private/resolver')
 const { replication } = require('./replication/resolver')
+const { revisionStats, revisionHistory } = require('./revisions/resolver')
+const { threads } = require('./threads/resolver')
 const { peers, gossip } = require('./gossip/resolver')
 const { blob, blobRemove, blobsList, blobsChanges } = require('./blobs/resolver')
 
 const Query = {
   whoami,
   message,
+  revisionStats,
+  revisionHistory,
+  threads,
   blob,
   peers,
   unbox

--- a/src/revisions/resolver.js
+++ b/src/revisions/resolver.js
@@ -1,0 +1,22 @@
+const pull = require('pull-stream')
+
+module.exports = {
+  revisionStats: (_, {}, {sbot}) => new Promise((resolve, reject) => {
+    pull(
+      sbot.revisions.stats(),
+      pull.collect((err, stats) => {
+        if(err) { reject(err) }
+        resolve(stats[0])
+      })
+    )
+  }),
+  revisionHistory: (_, {id}, {sbot}) => new Promise((resolve, reject) => {
+    pull(
+      sbot.revisions.history(id),
+      pull.collect((err, msgs) => {
+        if(err) { reject(err) }
+        resolve(msgs)
+      })
+    )
+  })
+}

--- a/src/revisions/type.js
+++ b/src/revisions/type.js
@@ -1,0 +1,8 @@
+const Revisions = `
+  type RevisionStats {
+    forked: Int
+    incomplete: Int
+  }
+`
+
+module.exports = () => [Revisions]

--- a/src/threads/resolver.js
+++ b/src/threads/resolver.js
@@ -1,9 +1,33 @@
 const pull = require('pull-stream')
 
 module.exports = {
-  threads: (_, {id}, {sbot}) => new Promise((resolve, reject) => {
+  threads: (_, opts, {sbot}) => new Promise((resolve, reject) => {
+    if(!opts.id) {
+      pull(
+        sbot.threads.public(opts),
+        pull.collect(function(err, msgs) {
+          if(err) { reject(err) }
+          else {
+            resolve(msgs)
+          }
+        })
+      )
+    } else {
+      pull(
+        sbot.threads.profile(opts),
+        pull.collect(function(err, msgs) {
+          if(err) { reject(err) }
+          else {
+            resolve(msgs)
+          }
+        })
+      )
+    }
+    
+  }),
+  thread: (_, opts, {sbot}) => new Promise((resolve, reject) => {
     pull(
-      sbot.threads.thread({root: id}),
+      sbot.threads.thread({root: opts.id}),
       pull.collect(function(err, msgs) {
         if(err) { reject(err) }
         else {

--- a/src/threads/resolver.js
+++ b/src/threads/resolver.js
@@ -26,8 +26,9 @@ module.exports = {
     
   }),
   thread: (_, opts, {sbot}) => new Promise((resolve, reject) => {
+    opts.root = opts.id
     pull(
-      sbot.threads.thread({root: opts.id}),
+      sbot.threads.thread(opts),
       pull.collect(function(err, msgs) {
         if(err) { reject(err) }
         else {

--- a/src/threads/resolver.js
+++ b/src/threads/resolver.js
@@ -1,0 +1,15 @@
+const pull = require('pull-stream')
+
+module.exports = {
+  threads: (_, {id}, {sbot}) => new Promise((resolve, reject) => {
+    pull(
+      sbot.threads.thread({root: id}),
+      pull.collect(function(err, msgs) {
+        if(err) { reject(err) }
+        else {
+          resolve(msgs)
+        }
+      })
+    )
+  })
+}

--- a/src/threads/type.js
+++ b/src/threads/type.js
@@ -1,0 +1,11 @@
+const Threads = `
+  type Thread {
+    messages: [Message]
+    full: Boolean
+  }
+  type Threads {
+    threads: [Thread]
+  }
+`
+
+module.exports = () => [Threads]

--- a/src/typeDefs.js
+++ b/src/typeDefs.js
@@ -1,5 +1,7 @@
 const DefaultMessage = require('./message/default/type')
 const Message = require('./message/type')
+const Revisions = require('./revisions/type')
+const SsbThreads = require('./threads/type')
 const Replication = require('./replication/type')
 const Gossip = require('./gossip/type')
 const Blob = require('./blobs/type')
@@ -14,6 +16,9 @@ const Query = `
   type Query {
     whoami: String
     message(id: String!): Message
+    revisionStats: RevisionStats
+    revisionHistory(id: String!): [PostMessage]
+    threads(id: String!): [Thread]
     blob(hash: String): Blob
     peers: [Peer]
     unbox: Message
@@ -63,6 +68,8 @@ module.exports = [
   Subscription,
   DefaultMessage,
   Message,
+  Revisions,
+  SsbThreads,
   Blob,
   Replication,
   Gossip,

--- a/src/typeDefs.js
+++ b/src/typeDefs.js
@@ -18,7 +18,8 @@ const Query = `
     message(id: String!): Message
     revisionStats: RevisionStats
     revisionHistory(id: String!): [PostMessage]
-    threads(id: String!): [Thread]
+    threads(id: String reverse: Boolean limit: Int threadMaxSize: Int allowlist: [String] blocklist: [String]): [Thread]
+    thread(id: String! reverse: Boolean limit: Int threadMaxSize: Int allowlist: [String] blocklist: [String]): [Thread]
     blob(hash: String): Blob
     peers: [Peer]
     unbox: Message

--- a/src/typeDefs.js
+++ b/src/typeDefs.js
@@ -19,7 +19,7 @@ const Query = `
     revisionStats: RevisionStats
     revisionHistory(id: String!): [PostMessage]
     threads(id: String reverse: Boolean limit: Int threadMaxSize: Int allowlist: [String] blocklist: [String]): [Thread]
-    thread(id: String! reverse: Boolean limit: Int threadMaxSize: Int allowlist: [String] blocklist: [String]): [Thread]
+    thread(id: String! threadMaxSize: Int): [Thread]
     blob(hash: String): Blob
     peers: [Peer]
     unbox: Message


### PR DESCRIPTION
Also a fix for the branch property of PostMessage type: surprisingly a branch can be a string of the key of the message being replied to or a set (array) of message keys. I don't understand how a PostMessage reply can be to more than one message??? But since the log is full of many branches defined this way I've changed it to always output an array of branch keys.